### PR TITLE
Make the lib file name relative

### DIFF
--- a/protoc-gen-code.sh
+++ b/protoc-gen-code.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-java -cp build/libs/protoc-gen-zap-java-all.jar zapsolutions.zap.protoc.ProtocPlugin "$@"
+java -cp build/libs/${PWD##*/}-all.jar zapsolutions.zap.protoc.ProtocPlugin "$@"


### PR DESCRIPTION
This makes the lib file name relative.

Before if the project folder had a different name than "protoc-gen-zap-java" the script execution failed.
Now it works.